### PR TITLE
Codegen fixups concerning dashes and jsr deps

### DIFF
--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -16,6 +16,7 @@ jobs:
         - v1.41
         - v1.43
         - v1.45
+        - v2.0
         - canary
       fail-fast: false # run each branch to completion
 

--- a/generation/codegen-structs.ts
+++ b/generation/codegen-structs.ts
@@ -291,7 +291,7 @@ export function generateStructsTypescript(surface: SurfaceMap, apiS: SurfaceApi)
         chunks.push('{');
         for (const [field, inner] of shape.fields) {
           const isReq = shape.required.includes(field);
-          chunks.push(`  ${field}${isReq ? '' : '?'}: ${generateType(inner)}${isReq ? '' : ' | null'};`);
+          chunks.push(`  ${maybeQuote(field)}${isReq ? '' : '?'}: ${generateType(inner)}${isReq ? '' : ' | null'};`);
         }
         chunks.push('}');
         return chunks.join('\n').replace(/\n/g, '\n  ');

--- a/generation/codegen.ts
+++ b/generation/codegen.ts
@@ -8,7 +8,17 @@ export async function writeApiModule(surface: SurfaceMap, api: SurfaceApi, categ
 
   function postProcess(text: string) {
     if (apisModuleRoot) {
-      text = text.replaceAll(/from "..\/..\//g, `from "${apisModuleRoot}`);
+      text = text.replaceAll(/from "..\/..\/([^"]+)"/g, (_, path) => {
+        if (apisModuleRoot.startsWith('jsr:')) {
+          if (path.includes('@')) {
+            return `from "${apisModuleRoot}${path.split('/')[1].replace('@', '/')}"`;
+          } else {
+            return `from "${apisModuleRoot}${path}"`;
+          }
+        } else {
+          return `from "${apisModuleRoot}${path}"`;
+        }
+      });
     }
     return text;
   }

--- a/generation/codegen.ts
+++ b/generation/codegen.ts
@@ -9,12 +9,8 @@ export async function writeApiModule(surface: SurfaceMap, api: SurfaceApi, categ
   function postProcess(text: string) {
     if (apisModuleRoot) {
       text = text.replaceAll(/from "..\/..\/([^"]+)"/g, (_, path) => {
-        if (apisModuleRoot.startsWith('jsr:')) {
-          if (path.includes('@')) {
-            return `from "${apisModuleRoot}${path.split('/')[1].replace('@', '/')}"`;
-          } else {
-            return `from "${apisModuleRoot}${path}"`;
-          }
+        if (apisModuleRoot.startsWith('jsr:') && path.includes('@')) {
+          return `from "${apisModuleRoot}${path.split('/')[1].replace('@', '/')}"`;
         } else {
           return `from "${apisModuleRoot}${path}"`;
         }

--- a/lib/README.md
+++ b/lib/README.md
@@ -32,6 +32,9 @@ see `/x/kubernetes_client` for more information.
 
 ## Changelog
 
+* `v0.5.3` on `2024-10-16`:
+  * Fix CRD codegen issues with particular definitions and when using JSR import paths.
+
 * `v0.5.2` on `2024-09-28`:
   * Includes 'builtin' APIs generated from K8s `v1.30.4`.
     * New kinds `ValidatingAdmissionPolicy`, `ServiceCIDR`, `ResourceSlice`


### PR DESCRIPTION
* Fixes #14 
  * I already had a `maybeQuote` function for this issue, but it was not consistently used.
* Fixes #15
  * Added new logic for rewriting the imports when the target starts with `jsr:`

## codegen output diff
Input CRD: https://github.com/zalando/postgres-operator/raw/refs/heads/master/charts/postgres-operator/crds/postgresqls.yaml

```diff
diff --git a/original/acid.zalan.do@v1/mod.ts b/fixed/acid.zalan.do@v1/mod.ts
index c0f09b6..fd641a4 100644
--- a/original/acid.zalan.do@v1/mod.ts
+++ b/fixed/acid.zalan.do@v1/mod.ts
@@ -3,7 +3,7 @@ export * from "./structs.ts";
 // Autogenerated API file for AcidZalanDoV1
 import * as c from "jsr:@cloudydeno/kubernetes-apis/common.ts";
 import * as operations from "jsr:@cloudydeno/kubernetes-apis/operations.ts";
-import * as MetaV1 from "jsr:@cloudydeno/kubernetes-apis/builtin/meta@v1/structs.ts";
+import * as MetaV1 from "jsr:@cloudydeno/kubernetes-apis/meta/v1";
 import * as AcidZalanDoV1 from "./structs.ts";
 
 export class AcidZalanDoV1Api {
diff --git a/original/acid.zalan.do@v1/structs.ts b/fixed/acid.zalan.do@v1/structs.ts
index 3225f13..d9702df 100644
--- a/original/acid.zalan.do@v1/structs.ts
+++ b/fixed/acid.zalan.do@v1/structs.ts
@@ -1,7 +1,7 @@
 // Autogenerated Schema file for AcidZalanDoV1
 import * as c from "jsr:@cloudydeno/kubernetes-apis/common.ts";
 
-import * as MetaV1 from "jsr:@cloudydeno/kubernetes-apis/builtin/meta@v1/structs.ts";
+import * as MetaV1 from "jsr:@cloudydeno/kubernetes-apis/meta/v1";
 type ListOf<T> = {
   metadata: MetaV1.ListMeta;
   items: Array<T>;
@@ -132,14 +132,14 @@ export interface postgresql {
       limits?: {
         cpu?: string | null;
         memory?: string | null;
-        hugepages-2Mi?: string | null;
-        hugepages-1Gi?: string | null;
+        'hugepages-2Mi'?: string | null;
+        'hugepages-1Gi'?: string | null;
       } | null;
       requests?: {
         cpu?: string | null;
         memory?: string | null;
-        hugepages-2Mi?: string | null;
-        hugepages-1Gi?: string | null;
+        'hugepages-2Mi'?: string | null;
+        'hugepages-1Gi'?: string | null;
       } | null;
     } | null;
     schedulerName?: string | null;
```